### PR TITLE
Use merge version (Issue 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,8 @@ Generates an OPAM compiler remote for active GitHub OCaml PRs
 
 === flags ===
 
-  [-compiler-version string]  OCaml compiler version
   [-github-repo string]       GitHub repository
   [-github-user string]       GitHub username
-  [-output-dir string]        Directory containing the OPAM repository
   [-k TOKEN_NAME]             Name of the token in git-jar
   [-build-info]               print info about this build and exit
   [-version]                  print the version of this build and exit

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Generates an OPAM compiler remote for active GitHub OCaml PRs
   [-github-repo string]       GitHub repository
   [-github-user string]       GitHub username
   [-output-dir string]        Directory containing the OPAM repository
+  [-k TOKEN_NAME]             Name of the token in git-jar
   [-build-info]               print info about this build and exit
   [-version]                  print the version of this build and exit
   [-help]                     print this help text and exit

--- a/sync.sh
+++ b/sync.sh
@@ -1,10 +1,9 @@
-#!/bin/sh -ex
+#!/bin/bash -e
 
 REPO=../auto-opam-repository
 UPSTREAM=git://github.com/ocaml/opam-repository
 GEN=`pwd`/generate.native
 PULL=`pwd`/create_pull_request.native
-V=4.03.0
 if [ ! -d ${REPO} ]; then
   git clone git@github.com:bactrian/opam-repository ${REPO}
 fi
@@ -12,11 +11,50 @@ fi
 BRANCH=sync-prs-`date +%s`
 HRDATE=`date +%c`
 cd $REPO
+# @@DRA Cleaner to ensure that origin/upstream is same as $UPSTREAM
+#       and do a fetch followed by hard reset to upstream
+git checkout -f master
+git reset --hard
 git pull $UPSTREAM master
 git checkout -b $BRANCH
 
-rm -rf compilers/${V}/${V}+pr*
-$GEN -compiler-version ${V}
+# This becomes a little less scary-looking in OPAM 2.0 when it's packages/ocaml/*+pr[0-9]*
+rm -rf compilers/*/*+pr[0-9]*
+printf "Creating switches"
+# IFS must be empty or multiple spaces coming out of $GEN will be squashed!
+IFS=''
+while IFS=' ' read -r pr user repo branch target url
+do
+  read -r descr
+  printf "."
+  VERSION=$(curl -s https://raw.githubusercontent.com/$user/$repo/$branch/VERSION | head -n 1)
+  VERSION=${VERSION%+*}
+  # trunk was mis-tagged 4.03.1 for a while
+  if [[ $target == "trunk" && $VERSION == "4.03.1" ]] ; then
+    VERSION=4.04.0
+  fi
+  # Uncomment below to get the old behaviour
+#  VERSION=4.05.0
+  NAME=$VERSION+pr$pr
+  DIR=compilers/$VERSION/$NAME
+  mkdir -p $DIR
+  printf "%s" "$descr" > $DIR/$NAME.descr
+  cat > $DIR/$NAME.comp <<EOF
+opam-version: "1"
+version: "$VERSION"
+src: "$url"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [ "base-unix" "base-bigarray" "base-threads" ]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]
+EOF
+done <<< $($GEN)
+echo
+
 git add compilers
 git commit -a -m 'Sync latest compiler pull requests' || true
 git push origin $BRANCH


### PR DESCRIPTION
This is a first cut at the suggestion in #11.

I probably too readily hack in bash - if Core has utility functions for downloading files, this could be just as easily done in `generate.ml` (or bringing in ocurl as a dependency). If on the other hand you don't mind the move to shell scripting that part, `README.md` and other docs for `generate.native` should be updated.

The changes can be seen in action at https://github.com/metastack/opam-repository/pull/12 (though this needs to be tested again before merging, as I made cosmetic changes while committing!)
